### PR TITLE
fix(inkscape): disable batch_process by default for headless CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'ukiryu', git: 'https://github.com/ukiryu/ukiryu.git', branch: 'feature/architecture-refactoring'
+gem 'ukiryu', git: 'https://github.com/ukiryu/ukiryu.git', branch: 'main'
 
 # Required for moxml/lutaml-model XML processing (not declared as dependency)
 gem 'nokogiri'

--- a/tools/inkscape/1.0.yaml
+++ b/tools/inkscape/1.0.yaml
@@ -153,8 +153,8 @@ profiles:
     - name: batch_process
       cli: "--batch-process"
       position_constraint: prefix
-      description: Close GUI after processing (required for headless)
-      default: true
+      description: Close GUI after processing (forces GUI to show, not for headless CI)
+      default: false
       assignment_delimiter: none
     name: export
   - description: Query document dimensions


### PR DESCRIPTION
## Summary

- Changed `batch_process` flag default from `true` to `false` in Inkscape 1.0.yaml
- Updated the description to accurately reflect that this flag forces GUI to show

## Background

According to Inkscape command-line documentation:

> `--batch-process`: Close GUI when done. **Only use this when you actually need a GUI. Otherwise you usually don't need (or want) this option, as it forces the GUI to show.**

The previous configuration had `default: true` with description "(required for headless)", which is **incorrect**. This flag was causing Windows CI failures in vectory because:

1. The `--batch-process` flag forces the GUI to show
2. Windows CI runs in a headless environment (no display)
3. Inkscape would return exit code 0 but fail to create output files

## Test Plan

- After this PR is merged, trigger Windows CI in vectory
- Verify that Inkscape export commands work correctly without `--batch-process`
- Confirm all 28 previously failing tests now pass