### PR TITLE
fix(inkscape): fix batch_process default in v2 implementation file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'ukiryu', git: 'https://github.com/ukiryu/ukiryu.git', branch: 'feature/architecture-refactoring'
+gem 'ukiryu', git: 'https://github.com/ukiryu/ukiryu.git', branch: 'main'
 
 # Required for moxml/lutaml-model XML processing (not declared as dependency)
 gem 'nokogiri'

--- a/tools/inkscape/1.0.yaml
+++ b/tools/inkscape/1.0.yaml
@@ -153,8 +153,8 @@ profiles:
     - name: batch_process
       cli: "--batch-process"
       position_constraint: prefix
-      description: Close GUI after processing (required for headless)
-      default: true
+      description: Close GUI after processing (forces GUI to show, not for headless CI)
+      default: false
       assignment_delimiter: none
     name: export
   - description: Query document dimensions

--- a/tools/inkscape/default/1.0.yaml
+++ b/tools/inkscape/default/1.0.yaml
@@ -150,8 +150,8 @@ execution_profiles:
     - name: batch_process
       cli: "--batch-process"
       position_constraint: prefix
-      description: Close GUI after processing (required for headless)
-      default: true
+      description: Close GUI after processing (forces GUI to show, not for headless CI)
+      default: false
       assignment_delimiter: none
     name: export
   - description: Query document dimensions


### PR DESCRIPTION
The previous PR #6 only fixed the v1 style file (tools/inkscape/1.0.yaml) but the v2 architecture loads from tools/inkscape/default/1.0.yaml.

This PR fixes the correct file to set batch_process default to false.

The --batch-process flag in Inkscape forces the GUI to show, which fails in headless CI environments.